### PR TITLE
Update AsyncWriter.js

### DIFF
--- a/lib/AsyncWriter.js
+++ b/lib/AsyncWriter.js
@@ -61,7 +61,8 @@ BufferedWriter.prototype = {
 
     end: function() {
         this.flush();
-        this._wrapped.end();
+        if(!this._wrapped.isTTY)
+            this._wrapped.end();
     },
     on: function(event, callback) {
         return this._wrapped.on(event, callback);


### PR DESCRIPTION
fix: don't close stream when it is process.std*
